### PR TITLE
Revert change to name of generated .nix include file for now

### DIFF
--- a/images/nixos.yaml
+++ b/images/nixos.yaml
@@ -39,7 +39,7 @@ packages:
 
 files:
   - name: conf-hostname
-    path: /etc/nixos/incus.nix
+    path: /etc/nixos/lxd.nix
     generator: template
     content: |-
       { lib, config, pkgs, ... }:


### PR DESCRIPTION
Fixes #831 - `/etc/nixos/configuration.nix` is generated upstream and still refers to `lxd.nix` under that name.